### PR TITLE
Added rgb8 encoding support

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -12,6 +12,10 @@ device_user_id: ""
 #  1_1CameraInfoManager.html#details
 camera_info_url: ""
 
+#  The image encoding format under which camera takes picture.
+#  The supported encoding are "mono8" and "rgb8"
+#image_encoding: mono8
+
 #  Binning factor to get downsampled images. It refers here to any camera
 #  setting which combines rectangular neighborhoods of pixels into larger
 #  "super-pixels." It reduces the resolution of the output image to

--- a/include/pylon_camera/internal/impl/pylon_camera_base.hpp
+++ b/include/pylon_camera/internal/impl/pylon_camera_base.hpp
@@ -801,26 +801,15 @@ bool PylonCameraImpl<CameraTraitT>::setShutterMode(const SHUTTER_MODE &shutter_m
 }
 
 template <typename CameraTraitT>
-std::string PylonCameraImpl<CameraTraitT>::imageEncoding() const
-{
-    switch ( image_encoding_ )
-    {
-        case PixelFormatEnums::PixelFormat_Mono8:
-            return sensor_msgs::image_encodings::MONO8;
-        default:
-            throw std::runtime_error("Currently, only mono8 cameras are supported");
-    }
-}
-
-template <typename CameraTraitT>
 int PylonCameraImpl<CameraTraitT>::imagePixelDepth() const
 {
-    switch ( image_pixel_depth_ )
+    if ( imageEncoding() == sensor_msgs::image_encodings::MONO8)
     {
-        case PixelSizeEnums::PixelSize_Bpp8:
-            return sizeof(uint8_t);
-        default:
-            throw std::runtime_error("Currently, only 8bit images are supported");
+        return (sizeof(uint8_t) * CHANNEL_MONO8);
+    }
+    else
+    {
+        return (sizeof(uint8_t) * CHANNEL_RGB8);
     }
 }
 

--- a/include/pylon_camera/internal/impl/pylon_camera_base.hpp
+++ b/include/pylon_camera/internal/impl/pylon_camera_base.hpp
@@ -264,13 +264,7 @@ bool PylonCameraImpl<CameraTraitT>::startGrabbing(const PylonCameraParameter& pa
             setShutterMode(parameters.shutter_mode_);
         }
 
-        if ( image_encoding_ != PixelFormatEnums::PixelFormat_Mono8 )
-        {
-            cam_->PixelFormat.SetValue(PixelFormatEnums::PixelFormat_Mono8);
-            image_encoding_ = cam_->PixelFormat.GetValue();
-            ROS_WARN_STREAM("Image encoding differing from 8-Bit Mono not yet "
-                << "implemented! Will switch to 8-Bit Mono");
-        }
+        setImageEncoding(parameters);
 
         cam_->StartGrabbing();
         user_output_selector_enums_ = detectAndCountNumUserOutputs();

--- a/include/pylon_camera/internal/impl/pylon_camera_gige.hpp
+++ b/include/pylon_camera/internal/impl/pylon_camera_gige.hpp
@@ -145,6 +145,29 @@ bool PylonGigECamera::applyCamSpecificStartupSettings(const PylonCameraParameter
 }
 
 template <>
+bool PylonGigECamera::setImageEncoding(const PylonCameraParameter& parameters)
+{
+    try
+    {
+        if (parameters.imageEncoding() == "rgb8")
+        {
+            cam_->PixelFormat.SetValue(PixelFormatEnums::PixelFormat_RGB8Planar);
+        }
+        else
+        {
+            cam_->PixelFormat.SetValue(PixelFormatEnums::PixelFormat_Mono8);
+        }
+        return true;
+    }
+    catch ( const GenICam::GenericException &e )
+    {
+        ROS_ERROR_STREAM("Error applying image encoding to GigE cameras: "
+                << e.GetDescription());
+        return false;
+    }
+}
+
+template <>
 bool PylonGigECamera::setupSequencer(const std::vector<float>& exposure_times,
                                      std::vector<float>& exposure_times_set)
 {

--- a/include/pylon_camera/internal/impl/pylon_camera_gige.hpp
+++ b/include/pylon_camera/internal/impl/pylon_camera_gige.hpp
@@ -168,6 +168,22 @@ bool PylonGigECamera::setImageEncoding(const PylonCameraParameter& parameters)
 }
 
 template <>
+std::string PylonGigECamera::imageEncoding() const
+{
+    switch ( image_encoding_ )
+    {
+        case PixelFormatEnums::PixelFormat_Mono8:
+            return sensor_msgs::image_encodings::MONO8;
+
+        case PixelFormatEnums::PixelFormat_RGB8Planar:
+            return sensor_msgs::image_encodings::RGB8;
+
+        default:
+            throw std::runtime_error("Currently, only mono8 and rgb8 cameras are supported");
+    }
+}
+
+template <>
 bool PylonGigECamera::setupSequencer(const std::vector<float>& exposure_times,
                                      std::vector<float>& exposure_times_set)
 {

--- a/include/pylon_camera/internal/impl/pylon_camera_usb.hpp
+++ b/include/pylon_camera/internal/impl/pylon_camera_usb.hpp
@@ -148,6 +148,21 @@ bool PylonUSBCamera::setImageEncoding(const PylonCameraParameter& parameters)
     }
 }
 
+template <>
+std::string PylonUSBCamera::imageEncoding() const
+{
+    switch ( image_encoding_ )
+    {
+        case PixelFormatEnums::PixelFormat_Mono8:
+            return sensor_msgs::image_encodings::MONO8;
+
+        case PixelFormatEnums::PixelFormat_RGB8:
+            return sensor_msgs::image_encodings::RGB8;
+
+        default:
+            throw std::runtime_error("Currently, only mono8 and rgb8 cameras are supported");
+    }
+}
 
 template <>
 bool PylonUSBCamera::setupSequencer(const std::vector<float>& exposure_times,

--- a/include/pylon_camera/internal/impl/pylon_camera_usb.hpp
+++ b/include/pylon_camera/internal/impl/pylon_camera_usb.hpp
@@ -126,6 +126,30 @@ bool PylonUSBCamera::applyCamSpecificStartupSettings(const PylonCameraParameter&
 }
 
 template <>
+bool PylonUSBCamera::setImageEncoding(const PylonCameraParameter& parameters)
+{
+    try
+    {
+        if (parameters.imageEncoding() == "rgb8")
+        {
+            cam_->PixelFormat.SetValue(PixelFormatEnums::PixelFormat_RGB8);
+        }
+        else
+        {
+            cam_->PixelFormat.SetValue(PixelFormatEnums::PixelFormat_Mono8);
+        }
+        return true;
+    }
+    catch ( const GenICam::GenericException &e )
+    {
+        ROS_ERROR_STREAM("Error applying image encoding to USB cameras: "
+                << e.GetDescription());
+        return false;
+    }
+}
+
+
+template <>
 bool PylonUSBCamera::setupSequencer(const std::vector<float>& exposure_times,
                                     std::vector<float>& exposure_times_set)
 {

--- a/include/pylon_camera/internal/pylon_camera.h
+++ b/include/pylon_camera/internal/pylon_camera.h
@@ -60,6 +60,8 @@ public:
 
     virtual bool applyCamSpecificStartupSettings(const PylonCameraParameter& parameters);
 
+    virtual bool setImageEncoding(const PylonCameraParameter& parameters);
+
     virtual bool startGrabbing(const PylonCameraParameter& parameters);
 
     virtual bool grab(std::vector<uint8_t>& image);

--- a/include/pylon_camera/pylon_camera.h
+++ b/include/pylon_camera/pylon_camera.h
@@ -39,6 +39,10 @@
 namespace pylon_camera
 {
 
+// Number of channels for image encoding
+#define CHANNEL_MONO8 1
+#define CHANNEL_RGB8  3
+
 /**
  * The PylonCamera base class. Create a new instance using the static create() functions.
  */

--- a/include/pylon_camera/pylon_camera_parameter.h
+++ b/include/pylon_camera/pylon_camera_parameter.h
@@ -84,6 +84,11 @@ public:
     const double& frameRate() const;
 
     /**
+     * Getter for the image_encoding_ read from ros-parameter server
+     */
+    std::string imageEncoding() const;
+
+    /**
      * Setter for the frame_rate_ initially set from ros-parameter server
      * The frame rate needs to be updated with the value the camera supports
      */
@@ -272,6 +277,11 @@ protected:
      * http://wiki.ros.org/camera_info_manager
      */
     std::string camera_info_url_;
+
+    /**
+     * Image encoding
+     */
+    std::string image_encoding_;
 };
 
 }  // namespace pylon_camera

--- a/src/pylon_camera/pylon_camera_node.cpp
+++ b/src/pylon_camera/pylon_camera_node.cpp
@@ -429,8 +429,17 @@ bool PylonCameraNode::grabImage()
     {
         cv_bridge_img_rect_->header.stamp = img_raw_msg_.header.stamp;
         assert(pinhole_model_->initialized());
-        cv::Mat img_raw = cv::Mat(img_raw_msg_.height, img_raw_msg_.width,
-                                  CV_8UC1, img_raw_msg_.data.data());
+        cv::Mat img_raw;
+        if ( pylon_camera_->imageEncoding() == "rgb8" )
+        {
+            img_raw = cv::Mat(img_raw_msg_.height, img_raw_msg_.width,
+                              CV_8UC3, img_raw_msg_.data.data());
+        }
+        else
+        {
+            img_raw = cv::Mat(img_raw_msg_.height, img_raw_msg_.width,
+                              CV_8UC1, img_raw_msg_.data.data());
+        }
         pinhole_model_->fromCameraInfo(camera_info_manager_->getCameraInfo());
         pinhole_model_->rectifyImage(img_raw, cv_bridge_img_rect_->image);
     }
@@ -466,10 +475,21 @@ void PylonCameraNode::grabImagesRectActionExecuteCB(
 
         for ( std::size_t i = 0; i < result.images.size(); ++i)
         {
-            cv::Mat cv_img_raw = cv::Mat(result.images[i].height,
-                    result.images[i].width,
-                    CV_8UC1,
-                    result.images[i].data.data());
+            cv::Mat cv_img_raw;
+            if ( pylon_camera_->imageEncoding() == "rgb8" )
+            {
+                cv_img_raw = cv::Mat(result.images[i].height,
+                                     result.images[i].width,
+                                     CV_8UC3,
+                                     result.images[i].data.data());
+            }
+            else
+            {
+                cv_img_raw = cv::Mat(result.images[i].height,
+                                     result.images[i].width,
+                                     CV_8UC1,
+                                     result.images[i].data.data());
+            }
             pinhole_model_->fromCameraInfo(camera_info_manager_->getCameraInfo());
             cv_bridge::CvImage cv_bridge_img_rect;
             cv_bridge_img_rect.header = result.images[i].header;

--- a/src/pylon_camera/pylon_camera_parameter.cpp
+++ b/src/pylon_camera/pylon_camera_parameter.cpp
@@ -37,6 +37,7 @@ PylonCameraParameter::PylonCameraParameter() :
         device_user_id_(""),
         frame_rate_(5.0),
         camera_info_url_(""),
+        image_encoding_("mono8"),
         binning_x_(1),
         binning_y_(1),
         binning_x_given_(false),
@@ -80,6 +81,8 @@ void PylonCameraParameter::readFromRosParameterServer(const ros::NodeHandle& nh)
     {
         nh.getParam("camera_info_url", camera_info_url_);
     }
+
+    nh.param<std::string>("image_encoding", image_encoding_, "mono8");
 
     binning_x_given_ = nh.hasParam("binning_x");
     if ( binning_x_given_ )
@@ -283,6 +286,11 @@ std::string PylonCameraParameter::shutterModeString() const
     {
         return "default_shutter_mode";
     }
+}
+
+std::string PylonCameraParameter::imageEncoding() const
+{
+    return image_encoding_;
 }
 
 const std::string& PylonCameraParameter::cameraFrame() const


### PR DESCRIPTION
In this pull request, I have added rgb8 support. Since I have to modify multiple files to add the feature, I have divided into 4 different commits. 

I made each commit as simple as possible, and described the intention of code change. Please review and let me know if additional updates are required.

As I mentioned previously, the changes are tested with Basler daA1600-60uc.
