### PR TITLE
Fix: Install udev rules

### DIFF
--- a/rosdep/pylon_sdk.rdmanifest
+++ b/rosdep/pylon_sdk.rdmanifest
@@ -39,6 +39,14 @@ install-script: |
   else
     sudo mv untarred/pylon5/* $PYLON_ROOT/
   fi
+  
+  RULES_DIR=/etc/udev/rules.d
+  RULE_FILE=69-basler-cameras.rules
+  echo "install udev rules to ${RULES_DIR}/${RULE_FILE}"
+  sudo cp $RULE_FILE $RULES_DIR
+  sudo udevadm control --reload-rules
+
+  
 
 check-presence-script: |
   #!/bin/bash


### PR DESCRIPTION
Udev Rules usually installed with setup-usb.sh of tar.gz

Without, camera will not be recognized in Ubuntu stock install