### PR TITLE
Fix: Installation failed du to return code 2

### DIFF
--- a/rosdep/pylon_sdk.rdmanifest
+++ b/rosdep/pylon_sdk.rdmanifest
@@ -44,8 +44,8 @@ install-script: |
   RULE_FILE=69-basler-cameras.rules
   echo "install udev rules to ${RULES_DIR}/${RULE_FILE}"
   sudo cp $RULE_FILE $RULES_DIR
-  sudo udevadm control --reload-rules
-
+  sudo udevadm control --reload-rules || true
+  echo "udev rules installed"
   
 
 check-presence-script: |


### PR DESCRIPTION
udevadm control can return failure ($? != 0)
When building docker containers, the or true does the trick