### PR TITLE
Add balance_white mode

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -19,6 +19,11 @@ camera_info_url: ""
 #  Default values are 'mono8' and 'rgb8'
 # image_encoding: "mono8"
 
+#  Mode of white balance.
+#  The supported modes are "continuous", "once" or "off"
+#  Default value is "" (empty) means default_balance_white_mode
+# balance_white: "continuous"
+
 #  Binning factor to get downsampled images. It refers here to any camera
 #  setting which combines rectangular neighborhoods of pixels into larger
 #  "super-pixels." It reduces the resolution of the output image to

--- a/include/pylon_camera/internal/impl/pylon_camera_base.hpp
+++ b/include/pylon_camera/internal/impl/pylon_camera_base.hpp
@@ -331,6 +331,8 @@ bool PylonCameraImpl<CameraTraitT>::startGrabbing(const PylonCameraParameter& pa
             return false;
         }
 
+        setBalanceWhite(parameters.balanceWhite());
+
         cam_->StartGrabbing();
         user_output_selector_enums_ = detectAndCountNumUserOutputs();
         device_user_id_ = cam_->DeviceUserID.GetValue();
@@ -441,6 +443,43 @@ bool PylonCameraImpl<CameraTrait>::grab(Pylon::CGrabResultPtr& grab_result)
         return false;
     }
     return true;
+}
+
+template <typename CameraTraitT>
+void PylonCameraImpl<CameraTraitT>::setBalanceWhite(const std::string& target_balance_white)
+{
+    if ( !target_balance_white.empty() )
+    {
+        if ( GenApi::IsAvailable(cam_->BalanceWhiteAuto) )
+        {
+            BalanceWhiteAutoEnums balance_white;
+
+            if ( target_balance_white == "off" )
+            {
+                balance_white = BalanceWhiteAutoEnums::BalanceWhiteAuto_Off;
+            }
+            else if ( target_balance_white == "continuous" )
+            {
+                balance_white = BalanceWhiteAutoEnums::BalanceWhiteAuto_Continuous;
+            }
+            else if ( target_balance_white == "once" )
+            {
+                balance_white = BalanceWhiteAutoEnums::BalanceWhiteAuto_Once;
+            }
+            else
+            {
+                ROS_WARN_STREAM("Desired image encoding parameter: '" << balance_white
+                    << "' is not supported");
+                return;
+            }
+            cam_->BalanceWhiteAuto.SetValue(balance_white);
+        }
+        else
+        {
+            ROS_WARN_STREAM("Trying to enable BalanceWhiteAuto mode, but "
+                << "the camera has no Auto Balance White");
+        }
+    }
 }
 
 template <typename CameraTraitT>

--- a/include/pylon_camera/internal/impl/pylon_camera_gige.hpp
+++ b/include/pylon_camera/internal/impl/pylon_camera_gige.hpp
@@ -43,6 +43,7 @@ namespace pylon_camera
 struct GigECameraTrait
 {
     typedef Pylon::CBaslerGigEInstantCamera CBaslerInstantCameraT;
+    typedef Basler_GigECameraParams::BalanceWhiteAutoEnums BalanceWhiteAutoEnums;
     typedef Basler_GigECameraParams::ExposureAutoEnums ExposureAutoEnums;
     typedef Basler_GigECameraParams::GainAutoEnums GainAutoEnums;
     typedef Basler_GigECameraParams::PixelFormatEnums PixelFormatEnums;
@@ -125,6 +126,12 @@ bool PylonGigECamera::applyCamSpecificStartupSettings(const PylonCameraParameter
 {
     try
     {
+        if ( GenApi::IsAvailable(cam_->BalanceWhiteAuto) )
+        {
+            // Make sure BalanceWhite is off, otherwise the camera might fail to start
+            cam_->BalanceWhiteAuto.SetValue(Basler_GigECameraParams::BalanceWhiteAuto_Off);
+        }
+
         // Remove all previous settings (sequencer etc.)
         // Default Setting = Free-Running
         cam_->UserSetSelector.SetValue(Basler_GigECameraParams::UserSetSelector_Default);

--- a/include/pylon_camera/internal/impl/pylon_camera_usb.hpp
+++ b/include/pylon_camera/internal/impl/pylon_camera_usb.hpp
@@ -43,6 +43,7 @@ namespace pylon_camera
 struct USBCameraTrait
 {
     typedef Pylon::CBaslerUsbInstantCamera CBaslerInstantCameraT;
+    typedef Basler_UsbCameraParams::BalanceWhiteAutoEnums BalanceWhiteAutoEnums;
     typedef Basler_UsbCameraParams::ExposureAutoEnums ExposureAutoEnums;
     typedef Basler_UsbCameraParams::GainAutoEnums GainAutoEnums;
     typedef Basler_UsbCameraParams::PixelFormatEnums PixelFormatEnums;
@@ -66,6 +67,12 @@ bool PylonUSBCamera::applyCamSpecificStartupSettings(const PylonCameraParameter&
 {
     try
     {
+        if ( GenApi::IsAvailable(cam_->BalanceWhiteAuto) )
+        {
+            // Make sure BalanceWhite is off, otherwise the camera might fail to start
+            cam_->BalanceWhiteAuto.SetValue(Basler_UsbCameraParams::BalanceWhiteAuto_Off);
+        }
+
         // Remove all previous settings (sequencer etc.)
         // Default Setting = Free-Running
         cam_->UserSetSelector.SetValue(Basler_UsbCameraParams::UserSetSelector_Default);

--- a/include/pylon_camera/internal/pylon_camera.h
+++ b/include/pylon_camera/internal/pylon_camera.h
@@ -71,6 +71,8 @@ public:
 
     virtual bool setShutterMode(const pylon_camera::SHUTTER_MODE& mode);
 
+    virtual void setBalanceWhite(const std::string& balance_white);
+
     virtual bool setROI(const sensor_msgs::RegionOfInterest target_roi,
                         sensor_msgs::RegionOfInterest& reached_roi);
     
@@ -147,6 +149,7 @@ public:
 
 protected:
     typedef typename CameraTraitT::CBaslerInstantCameraT CBaslerInstantCameraT;
+    typedef typename CameraTraitT::BalanceWhiteAutoEnums BalanceWhiteAutoEnums;
     typedef typename CameraTraitT::ExposureAutoEnums ExposureAutoEnums;
     typedef typename CameraTraitT::GainAutoEnums GainAutoEnums;
     typedef typename CameraTraitT::PixelFormatEnums PixelFormatEnums;

--- a/include/pylon_camera/pylon_camera.h
+++ b/include/pylon_camera/pylon_camera.h
@@ -129,6 +129,12 @@ public:
     virtual bool setShutterMode(const pylon_camera::SHUTTER_MODE& mode) = 0;
 
     /**
+     * Mode of white balance.
+       * @param balance_white the target white balance
+     */
+    virtual void setBalanceWhite(const std::string& balance_white) = 0;
+
+    /**
      * Update area of interest in the camera image
      * @param target_roi the target roi
      * @param reached_roi the roi that could be set

--- a/include/pylon_camera/pylon_camera_parameter.h
+++ b/include/pylon_camera/pylon_camera_parameter.h
@@ -95,6 +95,11 @@ public:
     const std::string& imageEncoding() const;
 
     /**
+     * Getter for the balance_white_ read from ros-parameter server
+     */
+    const std::string& balanceWhite() const;
+
+    /**
      * Setter for the frame_rate_ initially set from ros-parameter server
      * The frame rate needs to be updated with the value the camera supports
      */
@@ -326,6 +331,13 @@ protected:
      * 'bayer_gbrg8', 'bayer_rggb8' and 'yuv422'
      */
     std::string image_encoding_;
+
+    /**
+     * Mode of white balance.
+     * The supported modes are "continuous", "once" or "off"
+     * Default value is "" (empty) means default_balance_white_mode
+     */
+    std::string balance_white_;
 };
 
 }  // namespace pylon_camera

--- a/src/pylon_camera/pylon_camera_parameter.cpp
+++ b/src/pylon_camera/pylon_camera_parameter.cpp
@@ -39,6 +39,7 @@ PylonCameraParameter::PylonCameraParameter() :
         frame_rate_(5.0),
         camera_info_url_(""),
         image_encoding_(""),
+        balance_white_(""),
         binning_x_(1),
         binning_y_(1),
         binning_x_given_(false),
@@ -145,6 +146,11 @@ void PylonCameraParameter::readFromRosParameterServer(const ros::NodeHandle& nh)
         image_encoding_ = encoding;
     }
 
+    if ( nh.hasParam("balance_white") )
+    {
+        nh.getParam("balance_white", balance_white_);
+        std::cout << "balance white is given and has value " << balance_white_ << std::endl;
+    }
     // ##########################
     //  image intensity settings
     // ##########################
@@ -334,6 +340,11 @@ std::string PylonCameraParameter::shutterModeString() const
 const std::string& PylonCameraParameter::imageEncoding() const
 {
     return image_encoding_;
+}
+
+const std::string& PylonCameraParameter::balanceWhite() const
+{
+    return balance_white_;
 }
 
 const std::string& PylonCameraParameter::cameraFrame() const


### PR DESCRIPTION
Add `balance_white` mode supporting "continuous" and "once". Reading param from config file.

Tested with usb camera.

---
"Reset" of white_balance is required at camera startup ( before `cam_->UserSetLoad.Execute();`)
```
 cam_->BalanceWhiteAuto.SetValue(Basler_UsbCameraParams::BalanceWhiteAuto_Off);
```
in [pylon_camera_usb.hpp](https://github.com/braincorp/pylon_camera/blob/3df08afbbd8a30696dcee528e74b0aeff98320b5/include/pylon_camera/internal/impl/pylon_camera_usb.hpp#L73) and [pylon_camera_gige.hpp](https://github.com/braincorp/pylon_camera/blob/3df08afbbd8a30696dcee528e74b0aeff98320b5/include/pylon_camera/internal/impl/pylon_camera_gige.hpp#L132) (Maybe this can be solved differently).

Otherwise, it would result in `Brightness: 0` after reconnecting to camera (without disconnecting the cable).

Related: https://github.com/magazino/pylon_camera/issues/43, https://github.com/magazino/pylon_camera/issues/35